### PR TITLE
added an export for the MdlDialogOutletService

### DIFF
--- a/src/lib/components/dialog-outlet/index.ts
+++ b/src/lib/components/dialog-outlet/index.ts
@@ -7,6 +7,7 @@ import { MdlDialogOutletService } from './mdl-dialog-outlet.service';
 import { MdlBackdropOverlayComponent } from './mdl-backdrop-overlay.component';
 
 export * from './mdl-dialog-outlet.component';
+export * from './mdl-dialog-outlet.service';
 
 const PUBLIC_COMPONENTS = [
   MdlDialogInnerOutletComponent


### PR DESCRIPTION
The MdlDialogOutletService alternative to <dialog-outlet> seems to work great as a workaround for issue #147.  However, this currently only works if you are working off the /src files and are able to import MdlDialogOutletService directly from it's source TS file.

In the packaged library, the service in question is not currently exposed.  This change simply exports the the service so that it gets picked up in components/index.