### PR TITLE
<textarea> didn't use the "required" attribute

### DIFF
--- a/src/lib/components/textfield/mdl-textfield.component.ts
+++ b/src/lib/components/textfield/mdl-textfield.component.ts
@@ -64,6 +64,7 @@ const IS_DIRTY = 'is-dirty';
         (keydown)="keydownTextarea($event)"
         [(ngModel)]="value"
         [disabled]="disabled"
+        [required]="required"
         [autofocus]="autofocus"
         ></textarea>
      <input


### PR DESCRIPTION
Fixed a bug where <textarea> didn't use the "required" attribute, when all "input" were using it.

May be relevant to issue #36