### PR TITLE
Event emitter to detect state of modals being opened or closed

### DIFF
--- a/src/lib/components/dialog/mdl-dialog.service.spec.ts
+++ b/src/lib/components/dialog/mdl-dialog.service.spec.ts
@@ -413,7 +413,59 @@ describe('Service: MdlDialog', () => {
 
   }));
 
+  it('should emit an event when the first dialog instance is opened', async(() => {
+    let fixture = TestBed.createComponent(MdlTestViewComponent);
+    fixture.detectChanges();
 
+    spyOn(mdlDialogService.onDialogsOpenChanged, 'emit');
+
+    mdlDialogService.onDialogsOpenChanged.subscribe( ( dialogsOpen ) => {
+      expect(dialogsOpen).toBe(true);
+    });
+
+    let p = mdlDialogService.showCustomDialog({
+      component: TestCustomDialog,
+      providers: [{ provide: TEST, useValue: 'test'}]
+    });
+
+    let p2 = mdlDialogService.showCustomDialog({
+      component: TestCustomDialog,
+      providers: [{ provide: TEST, useValue: 'test 2'}]
+    });
+
+    expect(mdlDialogService.onDialogsOpenChanged.emit.calls.count()).toEqual(1);
+  }));
+
+  it('should emit an event when the last dialog instance is closed', async(() => {
+    let fixture = TestBed.createComponent(MdlTestViewComponent);
+    fixture.detectChanges();
+
+    spyOn(mdlDialogService.onDialogsOpenChanged, 'emit');
+
+    let p = mdlDialogService.showCustomDialog({
+      component: TestCustomDialog,
+      providers: [{ provide: TEST, useValue: 'test 1'}]
+    });
+
+    let p2 = mdlDialogService.showCustomDialog({
+      component: TestCustomDialog,
+      providers: [{ provide: TEST, useValue: 'test 2'}]
+    });
+
+    mdlDialogService.onDialogsOpenChanged.subscribe( ( dialogsOpen ) => {
+      expect(dialogsOpen).toBe(false);
+    });
+
+    p.subscribe( ( dialogRef ) => {
+      dialogRef.hide();
+
+      p2.subscribe( ( dialogRef2 ) => {
+        dialogRef2.hide();
+
+        expect(mdlDialogService.onDialogsOpenChanged.emit.calls.count()).toEqual(2); // 1 open, 1 close.
+      });
+    });
+  }));
 });
 
 

--- a/src/lib/components/dialog/mdl-dialog.service.ts
+++ b/src/lib/components/dialog/mdl-dialog.service.ts
@@ -75,10 +75,10 @@ export class MdlDialogService {
   private openDialogs = new Array<InternalMdlDialogReference>();
 
   /**
-   * Emits an event when the number of open dialogs changes.
-   * @returns A subscribable event emitter that provides the number of open dialogs.
+   * Emits an event when either all modals are closed, or one gets opened.
+   * @returns A subscribable event emitter that provides a boolean indicating whether a modal is open or not.
    */
-  public onOpenDialogCountChange: EventEmitter<number> = new EventEmitter<number>();
+  public onDialogsOpenChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
@@ -259,19 +259,21 @@ export class MdlDialogService {
   }
 
   private pushDialog(dialogRef: InternalMdlDialogReference) {
+    if (this.openDialogs.length == 0) { // first dialog being opened
+        this.onDialogsOpenChanged.emit(true);
+    }
+
     this.openDialogs.push(dialogRef);
     this.orderDialogStack();
-    this.updateOpenDialogCount();
   }
 
   private popDialog(dialogRef: InternalMdlDialogReference) {
     this.openDialogs.splice(this.openDialogs.indexOf(dialogRef), 1);
     this.orderDialogStack();
-    this.updateOpenDialogCount();
-  }
-
-  private updateOpenDialogCount() {
-    this.onOpenDialogCountChange.emit(this.openDialogs.length);
+    
+    if (this.openDialogs.length == 0) { // last dialog being closed
+      this.onDialogsOpenChanged.emit(false);
+    }
   }
 
   private orderDialogStack() {

--- a/src/lib/components/dialog/mdl-dialog.service.ts
+++ b/src/lib/components/dialog/mdl-dialog.service.ts
@@ -10,6 +10,7 @@ import {
   ApplicationRef,
   ViewContainerRef,
   TemplateRef,
+  EventEmitter
 } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import { Subject } from 'rxjs/Subject';
@@ -72,6 +73,12 @@ export class MdlDialogReference {
 export class MdlDialogService {
 
   private openDialogs = new Array<InternalMdlDialogReference>();
+
+  /**
+   * Emits an event when the number of open dialogs changes.
+   * @returns A subscribable event emitter that provides the number of open dialogs.
+   */
+  public onOpenDialogCountChange: EventEmitter<number> = new EventEmitter<number>();
 
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
@@ -254,11 +261,17 @@ export class MdlDialogService {
   private pushDialog(dialogRef: InternalMdlDialogReference) {
     this.openDialogs.push(dialogRef);
     this.orderDialogStack();
+    this.updateOpenDialogCount();
   }
 
   private popDialog(dialogRef: InternalMdlDialogReference) {
     this.openDialogs.splice(this.openDialogs.indexOf(dialogRef), 1);
     this.orderDialogStack();
+    this.updateOpenDialogCount();
+  }
+
+  private updateOpenDialogCount() {
+    this.onOpenDialogCountChange.emit(this.openDialogs.length);
   }
 
   private orderDialogStack() {


### PR DESCRIPTION
I added an event emitter to the MdlDialogService that provides an indicator for whether 1+ modals are active at any given time.

This allows the host application to react accordingly.  In my specific case, we need to apply some additional styling to the html body in order to prevent scrolling of the host page in the background.