### PR TITLE
fix dialog (imperative) examples to use observables

### DIFF
--- a/src/demo-app/app/dialog/dialog.component.html
+++ b/src/demo-app/app/dialog/dialog.component.html
@@ -44,7 +44,7 @@ These dialogs are created by the <i>MdlDialogService</i>.
   <![CDATA[
 <scripts>
   let result = this.dialogService.alert('This is a simple Alert');
-  result.then( () => console.log('alert closed') );
+  result.subscribe( () => console.log('alert closed') );
 </scripts>
 ]]>
 </pre>
@@ -62,7 +62,18 @@ These dialogs are created by the <i>MdlDialogService</i>.
   <![CDATA[
 <scripts>
   let result = this.dialogService.confirm('Would you like a mug of coffee?', 'No', 'Yes');
-  result.then( choosedOption => console.log( choosedOption === ConfirmResult.Confirmed ) );
+  // if you need both answers
+  result.subscribe( () => {
+      console.log('confirmed');
+    },
+    (err: any) => {
+      console.log('declined');
+    }
+  );
+  // if you only need the confirm answer
+  result.onErrorResumeNext().subscribe( () => {
+    console.log('confirmed 2');
+  });
 </scripts>
 ]]>
 </pre>
@@ -79,13 +90,24 @@ These dialogs are created by the <i>MdlDialogService</i>.
   <![CDATA[
 <scripts>
   let result = this.dialogService.confirm('Would you like a mug of coffee?', 'No', 'Yes', 'Excuse me');
-  result.then( choosedOption => console.log( choosedOption === ConfirmResult.Confirmed ) );
+  // if you need both answers
+  result.subscribe( () => {
+      console.log('confirmed');
+    },
+    (err: any) => {
+      console.log('declined');
+    }
+  );
+  // if you only need the confirm answer
+  result.onErrorResumeNext().subscribe( () => {
+    console.log('confirmed 2');
+  });
 </scripts>
 ]]>
 </pre>
 
 
-<h5>Dialog with choises</h5>
+<h5>Dialog with choices</h5>
 <button
         mdl-button
         mdl-button-type="raised"
@@ -131,13 +153,13 @@ These dialogs are created by the <i>MdlDialogService</i>.
       top: document.body.offsetHeight/2,
       width: 0} as IOpenCloseRect
   });
-  pDialog.then( (dialogReference) => console.log('dialog visible', dialogReference) );
+  pDialog.subscribe( (dialogReference) => console.log('dialog visible', dialogReference) );
 
 </scripts>
 ]]>
 </pre>
 
-<h5>A custom  login dialog</h5>
+<h5>A custom login dialog</h5>
 <button
         mdl-button
         mdl-button-type="raised"
@@ -154,7 +176,6 @@ These dialogs are created by the <i>MdlDialogService</i>.
     templateUrl: 'login-dialog.html'
   })
   export class LoginDialogComponent {
-
     constructor(private dialog: MdlDialogReference) {
 
       // register a listener if you want to be informed if the dialog is closed.
@@ -202,18 +223,18 @@ These dialogs are created by the <i>MdlDialogService</i>.
 <pre prism>
   <![CDATA[
 <scripts>
-  public showDialog() {
-
+  public showDialog($event: MouseEvent) {
     let pDialog = this.dialogService.showCustomDialog({
       component: LoginDialogComponent,
       providers: [{provide: TEST_VALUE, useValue: 'Just an example'}],
       isModal: true,
-      styles: {'width': '350px'},
+      styles: {'width': '300px'},
       clickOutsideToClose: true,
+      openFrom: $event,
       enterTransitionDuration: 400,
       leaveTransitionDuration: 400
     });
-    pDialog.then( (dialogReference: MdlDialogReference) => {
+    pDialog.subscribe( (dialogReference: MdlDialogReference) => {
       console.log('dialog visible', dialogReference);
     });
   }

--- a/src/demo-app/app/dialog/dialog.component.ts
+++ b/src/demo-app/app/dialog/dialog.component.ts
@@ -47,7 +47,7 @@ export class DialogDemo extends AbstractDemoComponent {
 
   public showConfirmMessage() {
     let result = this.dialogService.confirm('Would you like a mug of coffee?', 'No', 'Yes');
-    // if you need booth answers
+    // if you need both answers
     result.subscribe( () => {
         console.log('confirmed');
       },
@@ -58,12 +58,12 @@ export class DialogDemo extends AbstractDemoComponent {
     // if you only need the confirm answer
     result.onErrorResumeNext().subscribe( () => {
       console.log('confirmed 2');
-    })
+    });
   }
 
   public showConfirmMessageWithTitle() {
     let result = this.dialogService.confirm('Would you like a mug of coffee?', 'No', 'Yes', 'Excuse me');
-    // if you need booth answers
+    // if you need both answers
     result.subscribe( () => {
         console.log('confirmed');
       },
@@ -74,7 +74,7 @@ export class DialogDemo extends AbstractDemoComponent {
     // if you only need the confirm answer
     result.onErrorResumeNext().subscribe( () => {
       console.log('confirmed 2');
-    })
+    });
   }
 
   public showDialogFullWidthAction($event: MouseEvent) {


### PR DESCRIPTION
Imperative dialogs examples in demo app use promise based implementation of dialog service. Submitting the pull request to change it to observables