### PR TITLE
fix(dialog): do not import BrowserAnimationsModule

### DIFF
--- a/src/demo-app/app/app-module.ts
+++ b/src/demo-app/app/app-module.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular/core';
 import { BrowserModule,
   Title } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MdlModule } from './../../lib/components/index';
 import { RouterModule } from '@angular/router';
@@ -41,6 +42,7 @@ import { LoginModule } from './dialog/login.module';
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     ReactiveFormsModule,
     MdlModule,

--- a/src/lib/components/dialog/index.ts
+++ b/src/lib/components/dialog/index.ts
@@ -8,7 +8,6 @@ import { MdlDialogHostComponent } from './mdl-dialog-host.component';
 import { MdlAlertComponent } from './mdl-alert.component';
 import { MdlDialogOutletModule } from '../dialog-outlet/index';
 import { MdlButtonModule } from '../button/mdl-button.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 export * from './mdl-dialog.component';
 export * from './mdl-dialog.service';
@@ -30,8 +29,7 @@ const PRIVATE_COMPONENTS = [
     CommonModule,
     MdlCommonsModule,
     MdlButtonModule,
-    MdlDialogOutletModule.forRoot(),
-    BrowserAnimationsModule
+    MdlDialogOutletModule.forRoot()
   ],
   exports: [
     ...PUBLIC_COMPONENTS


### PR DESCRIPTION
Importing the `BrowserAnimationsModule` in the dialog breaks applications that use Angular `4.0.0-rc.2`. For that reason, it would be better to let users include the module themselves if they make use of angular-mdl's dialogs.

Fixes #639 