### PR TITLE
Support for data attribute on tabs panel

### DIFF
--- a/src/lib/components/tabs/mdl-tab-panel.component.ts
+++ b/src/lib/components/tabs/mdl-tab-panel.component.ts
@@ -33,6 +33,7 @@ export class MdlTabPanelComponent {
   @ContentChild(MdlTabPanelTitleComponent) public titleComponent;
   @Input('mdl-tab-panel-title') public title;
   @Input('disabled') public disabled;
+  @Input('mdl-tab-panel-data') public data;
   public isActive = false;
 
 }


### PR DESCRIPTION
I found a need of having to get custom data for a specific tab and thought it could be useful to be able to send data to the tabs-panel component.

How it would be used: add mdl-tab-panel-data with a JSON object.
![template](https://cloud.githubusercontent.com/assets/13257322/24099434/814a133e-0d6f-11e7-8c7e-e4ea76cb1afa.png)

Then on tab change, parse the object: 
![tabschanged](https://cloud.githubusercontent.com/assets/13257322/24099433/812d9902-0d6f-11e7-8305-eee19254f10b.png)

