### PR TITLE
add openDrawer and openDrawerOnSmallScreens method on mdl-layout

### DIFF
--- a/src/lib/components/layout/mdl-layout.component.spec.ts
+++ b/src/lib/components/layout/mdl-layout.component.spec.ts
@@ -340,6 +340,93 @@ describe('Component: MdlLayout', () => {
     expect(titleDebugElement.nativeElement.nodeName).toEqual('SPAN');
   }));
 
+  it('should open the drawer if openDrawer is called', ( done ) => {
+
+    TestBed.overrideComponent(MdlTestLayoutComponent, { set: {
+      template: `
+          <mdl-layout>
+            <mdl-layout-header></mdl-layout-header>
+            <mdl-layout-drawer></mdl-layout-drawer>
+            <mdl-layout-content></mdl-layout-content>
+          </mdl-layout>
+        ` }
+    });
+    let fixture = TestBed.createComponent(MdlTestLayoutComponent);
+    fixture.detectChanges();
+    let layoutComponent = fixture.debugElement.query(By.directive(MdlLayoutComponent)).componentInstance;
+
+    layoutComponent.closeDrawer();
+    fixture.detectChanges();
+
+    let drawer = fixture.debugElement.query(By.directive(MdlLayoutDrawerComponent)).componentInstance;
+    expect(drawer.isDrawerVisible).toBe(false);
+
+    layoutComponent.openDrawer();
+    expect(drawer.isDrawerVisible).toBe(true);
+
+    done();
+  });
+
+  it('should close the drawer if closeDrawer is called', ( done ) => {
+
+    TestBed.overrideComponent(MdlTestLayoutComponent, { set: {
+      template: `
+          <mdl-layout>
+            <mdl-layout-header></mdl-layout-header>
+            <mdl-layout-drawer></mdl-layout-drawer>
+            <mdl-layout-content></mdl-layout-content>
+          </mdl-layout>
+        ` }
+    });
+    let fixture = TestBed.createComponent(MdlTestLayoutComponent);
+    fixture.detectChanges();
+    let layoutComponent = fixture.debugElement.query(By.directive(MdlLayoutComponent)).componentInstance;
+
+    layoutComponent.openDrawer();
+    fixture.detectChanges();
+
+    let drawer = fixture.debugElement.query(By.directive(MdlLayoutDrawerComponent)).componentInstance;
+    expect(drawer.isDrawerVisible).toBe(true);
+
+    layoutComponent.closeDrawer();
+    expect(drawer.isDrawerVisible).toBe(false);
+
+    done();
+  });
+
+  it('should open the drawer on small screens if openDrawerOnSmallScreens is called', ( done ) => {
+
+    TestBed.overrideComponent(MdlTestLayoutComponent, { set: {
+      template: `
+          <mdl-layout mdl-layout-fixed-drawer>
+            <mdl-layout-header></mdl-layout-header>
+            <mdl-layout-drawer></mdl-layout-drawer>
+            <mdl-layout-content></mdl-layout-content>
+          </mdl-layout>
+        ` }
+    });
+    let fixture = TestBed.createComponent(MdlTestLayoutComponent);
+    fixture.detectChanges();
+    let layoutComponent = fixture.debugElement.query(By.directive(MdlLayoutComponent)).componentInstance;
+
+    layoutComponent.closeDrawer();
+    fixture.detectChanges();
+
+    let drawer = fixture.debugElement.query(By.directive(MdlLayoutDrawerComponent)).componentInstance;
+    expect(drawer.isDrawerVisible).toBe(false);
+
+    // small screen
+    layoutComponent.onQueryChange(true);
+    fixture.detectChanges();
+
+    expect(layoutComponent.isSmallScreen).toBe(true);
+
+    layoutComponent.openDrawerOnSmallScreens();
+    expect(drawer.isDrawerVisible).toBe(true);
+
+    done();
+  });
+
   it('should close the drawer on small screens if closeDrawerOnSmallScreens is called', ( done ) => {
 
     TestBed.overrideComponent(MdlTestLayoutComponent, { set: {
@@ -368,6 +455,60 @@ describe('Component: MdlLayout', () => {
     expect(layoutComponent.isSmallScreen).toBe(true);
 
     layoutComponent.closeDrawerOnSmallScreens();
+    expect(drawer.isDrawerVisible).toBe(false);
+
+    done();
+  });
+
+  it('should open the drawer from close state if toggleDrawer is called', ( done ) => {
+
+    TestBed.overrideComponent(MdlTestLayoutComponent, { set: {
+      template: `
+          <mdl-layout>
+            <mdl-layout-header></mdl-layout-header>
+            <mdl-layout-drawer></mdl-layout-drawer>
+            <mdl-layout-content></mdl-layout-content>
+          </mdl-layout>
+        ` }
+    });
+    let fixture = TestBed.createComponent(MdlTestLayoutComponent);
+    fixture.detectChanges();
+    let layoutComponent = fixture.debugElement.query(By.directive(MdlLayoutComponent)).componentInstance;
+
+    layoutComponent.closeDrawer();
+    fixture.detectChanges();
+
+    let drawer = fixture.debugElement.query(By.directive(MdlLayoutDrawerComponent)).componentInstance;
+    expect(drawer.isDrawerVisible).toBe(false);
+
+    layoutComponent.toggleDrawer();
+    expect(drawer.isDrawerVisible).toBe(true);
+
+    done();
+  });
+
+  it('should close the drawer from open state if toggleDrawer is called', ( done ) => {
+
+    TestBed.overrideComponent(MdlTestLayoutComponent, { set: {
+      template: `
+          <mdl-layout>
+            <mdl-layout-header></mdl-layout-header>
+            <mdl-layout-drawer></mdl-layout-drawer>
+            <mdl-layout-content></mdl-layout-content>
+          </mdl-layout>
+        ` }
+    });
+    let fixture = TestBed.createComponent(MdlTestLayoutComponent);
+    fixture.detectChanges();
+    let layoutComponent = fixture.debugElement.query(By.directive(MdlLayoutComponent)).componentInstance;
+
+    layoutComponent.openDrawer();
+    fixture.detectChanges();
+
+    let drawer = fixture.debugElement.query(By.directive(MdlLayoutDrawerComponent)).componentInstance;
+    expect(drawer.isDrawerVisible).toBe(true);
+
+    layoutComponent.toggleDrawer();
     expect(drawer.isDrawerVisible).toBe(false);
 
     done();

--- a/src/lib/components/layout/mdl-layout.component.ts
+++ b/src/lib/components/layout/mdl-layout.component.ts
@@ -286,6 +286,13 @@ export class MdlLayoutComponent implements AfterContentInit, OnDestroy, OnChange
     }
   }
 
+  public openDrawer() {
+    this.isDrawerVisible = true;
+    if (this.drawer) {
+      this.setDrawerVisible(true);
+    }
+  }
+
   private setDrawerVisible(visible: boolean){
     this.drawer.isDrawerVisible = visible;
     this.drawer.isDrawerVisible ? this.onOpen.emit() : this.onClose.emit();
@@ -329,6 +336,12 @@ export class MdlLayoutComponent implements AfterContentInit, OnDestroy, OnChange
   public closeDrawerOnSmallScreens() {
     if (this.isSmallScreen && this.isDrawerVisible) {
       this.closeDrawer();
+    }
+  }
+
+  public openDrawerOnSmallScreens() {
+    if (this.isSmallScreen && !this.isDrawerVisible) {
+      this.openDrawer();
     }
   }
 


### PR DESCRIPTION
mdl-layout.component only have closeDrawer(), toggleDrawer() and closeDrawerOnSmallScreens().
Drawer open related methods are missing.

Of cause we would operate drawer to open with public isDrawerVisible and toggeDrawer() etc.
But I think better adding openDrawer() and openDrawerOnSmallScreens() to mdl-layout.coponent.

