### PR TITLE
Fixed issue with maxlength for textfield component when rows is set

### DIFF
--- a/src/lib/components/textfield/mdl-textfield.component.ts
+++ b/src/lib/components/textfield/mdl-textfield.component.ts
@@ -70,6 +70,7 @@ const IS_DIRTY = 'is-dirty';
         [required]="required"
         [autofocus]="autofocus"
         [readonly]="readonly"
+        [maxlength]="maxlength"
         ></textarea>
      <input
         *ngIf="!rows"


### PR DESCRIPTION
Fixed issue  with maxlength for textfield component when rows is set (rendered as textarea) (#1049)