### PR TITLE
Fixed misprint with menu components array

### DIFF
--- a/src/lib/components/menu/mdl-menu.component.ts
+++ b/src/lib/components/menu/mdl-menu.component.ts
@@ -49,7 +49,8 @@ export class MdlMenuRegisty {
   }
 
   public remove(menuComponent: MdlMenuComponent) {
-    this.menuComponents.slice(this.menuComponents.indexOf(menuComponent), 1);
+    const fromIndex = this.menuComponents.indexOf(menuComponent);
+    this.menuComponents.splice(fromIndex, 1);
   }
 
   public hideAllExcept(menuComponent: MdlMenuComponent) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -14,7 +14,6 @@
     "typeRoots": ["./../node_modules/@types"],
     "types": [
       "node",
-      "protractor",
       "jasmine"
     ]
   },


### PR DESCRIPTION
Currently destroyed menu components are not removed from `MdlMenuRegisty` due to misprint in `Array.prototype.splice`.
This leads to continuous calls of `MdlMenuComponent.hide()` in`MdlMenuRegisty.hideAllExcept()` for menu components that are already destroyed.
In my use case this leads to TypeError: **Cannot read property 'toArray' of undefined** when user clicks on any alive menu drop-down component. 
This PR should fix the misprint so the components are removed correctly from `MdlMenuRegisty`.

Commit summary:
- fixed the build error: `Can not find 'protractor' typings`
- fixed misprint with menu components array