### PR TITLE
changed action from tuple to array of actions

### DIFF
--- a/src/lib/components/dialog/mdl-dialog-configuration.ts
+++ b/src/lib/components/dialog/mdl-dialog-configuration.ts
@@ -120,7 +120,7 @@ export interface IMdlSimpleDialogConfiguration extends IMdlDialogConfiguration {
   /**
    * the actions that are used for this dialog (the order will be reversed by mdl.
    */
-  actions: [IMdlDialogAction];
+  actions: IMdlDialogAction[];
   /**
    * should the actions be displayed as full width actions. every aciton is one row.
    */


### PR DESCRIPTION
Fixed length tuples are enforced now from typescript 2.7, and it is documented as a breaking change.

https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes

Previous interpretation of this definition was that actions should contain one or more actions, however that is not the case anymore. 

There is a proposal to add variable length tuples, however that is not implemented yet, and for now, current definition is producing compile time error with typescript >=2.7

Current fix will allow interoperability until https://github.com/Microsoft/TypeScript/issues/6229 is being agreed upon.